### PR TITLE
Per pixel token

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,9 +35,11 @@
         "symfony/http-kernel": "^4.4 || ^5.1.5",
         "symfony/options-resolver": "^4.4 || ^5.0",
         "symfony/routing": "^4.4 || ^5.0",
+        "symfony/security": "^4.4 || ^5.0",
         "symfony/security-bundle": "^4.4 || ^5.0",
         "symfony/uid": "^4.4 || ^5.0",
         "symfony/workflow": "^4.4 || ^5.0",
+        "twig/twig": "^2.0",
         "webmozart/assert": "^1.10"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,7 @@
         "symfony/security-bundle": "^4.4 || ^5.0",
         "symfony/uid": "^4.4 || ^5.0",
         "symfony/workflow": "^4.4 || ^5.0",
-        "twig/twig": "^2.0",
+        "twig/twig": "^2.0 || ^3.0",
         "webmozart/assert": "^1.10"
     },
     "require-dev": {

--- a/src/Client/Client.php
+++ b/src/Client/Client.php
@@ -6,6 +6,7 @@ namespace Setono\SyliusFacebookPlugin\Client;
 
 use Setono\SyliusFacebookPlugin\Model\PixelEventInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
+use Symfony\Contracts\HttpClient\ResponseInterface;
 use Webmozart\Assert\Assert;
 
 final class Client implements ClientInterface
@@ -38,13 +39,15 @@ final class Client implements ClientInterface
         $pixelId = $pixel->getPixelId();
         Assert::notNull($pixelId);
 
+        $accessToken = $pixel->getCustomAccessToken() ?? $this->accessToken;
+
         $options = [
             'headers' => [
                 'Content-Type' => 'application/x-www-form-urlencoded',
                 'Accept' => 'application/json',
             ],
             'body' => [
-                'access_token' => $this->accessToken,
+                'access_token' => $accessToken,
                 'data' => json_encode([
                     $pixelEvent->getData(),
                 ]),

--- a/src/Controller/Action/Pixel/ResetFailedEventsAction.php
+++ b/src/Controller/Action/Pixel/ResetFailedEventsAction.php
@@ -11,7 +11,6 @@ use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\Session\Flash\FlashBagInterface;
-use Symfony\Component\HttpFoundation\Session\SessionInterface;
 use Symfony\Component\HttpKernel\Exception\HttpException;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Component\Security\Csrf\CsrfToken;
@@ -26,28 +25,24 @@ final class ResetFailedEventsAction
 
     private PixelEventRepositoryInterface $pixelEventRepository;
 
-    private SessionInterface $session;
-
     private UrlGeneratorInterface $urlGeneratorInterface;
 
     public function __construct(
         PixelRepositoryInterface $pixelRepository,
         CsrfTokenManagerInterface $csrfTokenManager,
         PixelEventRepositoryInterface $pixelEventRepository,
-        SessionInterface $session,
         UrlGeneratorInterface $urlGeneratorInterface
     ) {
         $this->pixelRepository = $pixelRepository;
         $this->csrfTokenManager = $csrfTokenManager;
         $this->pixelEventRepository = $pixelEventRepository;
-        $this->session = $session;
         $this->urlGeneratorInterface = $urlGeneratorInterface;
     }
 
     public function __invoke(Request $request, int $id): Response
     {
         /** @var FlashBagInterface $flashBag */
-        $flashBag = $this->session->getBag('flashes');
+        $flashBag = $request->getSession()->getBag('flashes');
 
         /** @var PixelInterface|null $pixel */
         $pixel = $this->pixelRepository->find($id);

--- a/src/Controller/Action/Pixel/ResetFailedEventsAction.php
+++ b/src/Controller/Action/Pixel/ResetFailedEventsAction.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Setono\SyliusFacebookPlugin\Controller\Action\Pixel;
+
+use Setono\SyliusFacebookPlugin\Model\PixelInterface;
+use Setono\SyliusFacebookPlugin\Repository\PixelEventRepositoryInterface;
+use Setono\SyliusFacebookPlugin\Repository\PixelRepositoryInterface;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpFoundation\Session\Flash\FlashBagInterface;
+use Symfony\Component\HttpFoundation\Session\SessionInterface;
+use Symfony\Component\HttpKernel\Exception\HttpException;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+use Symfony\Component\Security\Csrf\CsrfToken;
+use Symfony\Component\Security\Csrf\CsrfTokenManagerInterface;
+use Webmozart\Assert\Assert;
+
+final class ResetFailedEventsAction
+{
+    private PixelRepositoryInterface $pixelRepository;
+
+    private CsrfTokenManagerInterface $csrfTokenManager;
+
+    private PixelEventRepositoryInterface $pixelEventRepository;
+
+    private SessionInterface $session;
+
+    private UrlGeneratorInterface $urlGeneratorInterface;
+
+    public function __construct(
+        PixelRepositoryInterface $pixelRepository,
+        CsrfTokenManagerInterface $csrfTokenManager,
+        PixelEventRepositoryInterface $pixelEventRepository,
+        SessionInterface $session,
+        UrlGeneratorInterface $urlGeneratorInterface
+    ) {
+        $this->pixelRepository = $pixelRepository;
+        $this->csrfTokenManager = $csrfTokenManager;
+        $this->pixelEventRepository = $pixelEventRepository;
+        $this->session = $session;
+        $this->urlGeneratorInterface = $urlGeneratorInterface;
+    }
+
+    public function __invoke(Request $request, int $id): Response
+    {
+        /** @var FlashBagInterface $flashBag */
+        $flashBag = $this->session->getBag('flashes');
+
+        /** @var PixelInterface|null $pixel */
+        $pixel = $this->pixelRepository->find($id);
+        Assert::notNull($pixel);
+
+        $csrfToken = $request->request->get('_csrf_token');
+        Assert::string($csrfToken);
+        if (!$this->isCsrfTokenValid((string) $pixel->getId(), $csrfToken)) {
+            throw new HttpException(Response::HTTP_FORBIDDEN, 'Invalid csrf token.');
+        }
+
+        $this->pixelEventRepository->resetFailedByPixel($pixel);
+
+        $flashBag->add('success', 'setono_sylius_facebook.pixel.failed_events_reset');
+
+        return new RedirectResponse(
+            $this->getRedirectUrl($request, 'setono_sylius_facebook_admin_pixel_index')
+        );
+    }
+
+    private function getRedirectUrl(Request $request, string $defaultRoute): string
+    {
+        $syliusParameters = [];
+
+        if ($request->attributes->has('_sylius')) {
+            /** @var array|mixed $syliusParameters */
+            $syliusParameters = $request->attributes->get('_sylius');
+            Assert::isArray($syliusParameters);
+        }
+
+        /** @var string|mixed $route */
+        $route = $syliusParameters['redirect']['route'] ?? $defaultRoute;
+        Assert::string($route);
+
+        /** @var array|mixed $parameters */
+        $parameters = $syliusParameters['redirect']['parameters'] ?? [];
+        Assert::isArray($parameters);
+
+        return $this->urlGeneratorInterface->generate($route, $parameters);
+    }
+
+    private function isCsrfTokenValid(string $id, ?string $token): bool
+    {
+        return $this->csrfTokenManager->isTokenValid(new CsrfToken($id, $token));
+    }
+}

--- a/src/Doctrine/ORM/PixelEventRepository.php
+++ b/src/Doctrine/ORM/PixelEventRepository.php
@@ -94,6 +94,21 @@ class PixelEventRepository extends EntityRepository implements PixelEventReposit
         }
     }
 
+    public function resetFailedByPixel(PixelInterface $pixel): void
+    {
+        $this->createQueryBuilder('o')
+            ->update()
+            ->set('o.state', ':initialState')
+            ->setParameter('initialState', PixelEventInterface::STATE_PENDING, Types::STRING)
+            ->andWhere('o.pixel = :pixel')
+            ->setParameter('pixel', $pixel)
+            ->andWhere('o.state = :state')
+            ->setParameter('state', PixelEventInterface::STATE_FAILED, Types::STRING)
+            ->getQuery()
+            ->execute()
+        ;
+    }
+
     public function removeSent(int $delay = 0): int
     {
         $qb = $this->_em->createQueryBuilder()

--- a/src/Doctrine/ORM/PixelEventRepository.php
+++ b/src/Doctrine/ORM/PixelEventRepository.php
@@ -18,9 +18,8 @@ class PixelEventRepository extends EntityRepository implements PixelEventReposit
 {
     public function getCountByPixelAndState(PixelInterface $pixel, string $state): int
     {
-        return (int) $this->getEntityManager()->createQueryBuilder()
+        return (int) $this->createQueryBuilder('o')
             ->select('count(o)')
-            ->from($this->_entityName, 'o')
             ->andWhere('o.pixel = :pixel')
             ->setParameter('pixel', $pixel)
             ->andWhere('o.state = :state')

--- a/src/Doctrine/ORM/PixelEventRepository.php
+++ b/src/Doctrine/ORM/PixelEventRepository.php
@@ -9,12 +9,27 @@ use DateTime;
 use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\QueryBuilder;
 use Setono\SyliusFacebookPlugin\Model\PixelEventInterface;
+use Setono\SyliusFacebookPlugin\Model\PixelInterface;
 use Setono\SyliusFacebookPlugin\Repository\PixelEventRepositoryInterface;
 use Sylius\Bundle\ResourceBundle\Doctrine\ORM\EntityRepository;
 use Webmozart\Assert\Assert;
 
 class PixelEventRepository extends EntityRepository implements PixelEventRepositoryInterface
 {
+    public function getCountByPixelAndState(PixelInterface $pixel, string $state): int
+    {
+        return (int) $this->getEntityManager()->createQueryBuilder()
+            ->select('count(o)')
+            ->from($this->_entityName, 'o')
+            ->andWhere('o.pixel = :pixel')
+            ->setParameter('pixel', $pixel)
+            ->andWhere('o.state = :state')
+            ->setParameter('state', $state)
+            ->getQuery()
+            ->getSingleScalarResult()
+            ;
+    }
+
     public function hasConsentedPending(int $delay = 0): bool
     {
         $qb = $this->createQueryBuilder('o')

--- a/src/Form/Type/PixelType.php
+++ b/src/Form/Type/PixelType.php
@@ -18,7 +18,7 @@ final class PixelType extends AbstractResourceType
         $builder
             ->add('pixelId', IntegerType::class, [
                 'label' => 'setono_sylius_facebook.form.pixel.pixel_id',
-                'help' => 'Get it from https://www.facebook.com/events_manager2',
+                'help' => 'setono_sylius_facebook.form.pixel.pixel_id_help',
                 'attr' => [
                     'min' => 1,
                     'placeholder' => 'setono_sylius_facebook.form.pixel.pixel_id_placeholder',
@@ -26,6 +26,7 @@ final class PixelType extends AbstractResourceType
             ])
             ->add('customAccessToken', TextareaType::class, [
                 'label' => 'setono_sylius_facebook.form.pixel.custom_access_token',
+                'help' => 'setono_sylius_facebook.form.pixel.custom_access_token_help',
                 'required' => false,
                 'attr' => [
                     'rows' => 3,

--- a/src/Form/Type/PixelType.php
+++ b/src/Form/Type/PixelType.php
@@ -8,6 +8,7 @@ use Sylius\Bundle\ChannelBundle\Form\Type\ChannelChoiceType;
 use Sylius\Bundle\ResourceBundle\Form\Type\AbstractResourceType;
 use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
 use Symfony\Component\Form\Extension\Core\Type\IntegerType;
+use Symfony\Component\Form\Extension\Core\Type\TextareaType;
 use Symfony\Component\Form\FormBuilderInterface;
 
 final class PixelType extends AbstractResourceType
@@ -21,6 +22,14 @@ final class PixelType extends AbstractResourceType
                 'attr' => [
                     'min' => 1,
                     'placeholder' => 'setono_sylius_facebook.form.pixel.pixel_id_placeholder',
+                ],
+            ])
+            ->add('customAccessToken', TextareaType::class, [
+                'label' => 'setono_sylius_facebook.form.pixel.custom_access_token',
+                'required' => false,
+                'attr' => [
+                    'rows' => 3,
+                    'placeholder' => 'setono_sylius_facebook.form.pixel.custom_access_token_placeholder',
                 ],
             ])
             ->add('enabled', CheckboxType::class, [

--- a/src/Model/Pixel.php
+++ b/src/Model/Pixel.php
@@ -17,6 +17,8 @@ class Pixel implements PixelInterface
 
     protected ?string $pixelId = null;
 
+    protected ?string $customAccessToken = null;
+
     /**
      * @var Collection|BaseChannelInterface[]
      *
@@ -47,6 +49,16 @@ class Pixel implements PixelInterface
     public function setPixelId(string $pixelId): void
     {
         $this->pixelId = $pixelId;
+    }
+
+    public function getCustomAccessToken(): ?string
+    {
+        return $this->customAccessToken;
+    }
+
+    public function setCustomAccessToken(?string $customAccessToken): void
+    {
+        $this->customAccessToken = $customAccessToken;
     }
 
     public function getChannels(): Collection

--- a/src/Model/PixelInterface.php
+++ b/src/Model/PixelInterface.php
@@ -15,4 +15,8 @@ interface PixelInterface extends ResourceInterface, ToggleableInterface, Channel
     public function getPixelId(): ?string;
 
     public function setPixelId(string $pixelId): void;
+
+    public function getCustomAccessToken(): ?string;
+
+    public function setCustomAccessToken(?string $customAccessToken): void;
 }

--- a/src/Repository/PixelEventRepositoryInterface.php
+++ b/src/Repository/PixelEventRepositoryInterface.php
@@ -5,10 +5,13 @@ declare(strict_types=1);
 namespace Setono\SyliusFacebookPlugin\Repository;
 
 use Setono\SyliusFacebookPlugin\Model\PixelEventInterface;
+use Setono\SyliusFacebookPlugin\Model\PixelInterface;
 use Sylius\Component\Resource\Repository\RepositoryInterface;
 
 interface PixelEventRepositoryInterface extends RepositoryInterface
 {
+    public function getCountByPixelAndState(PixelInterface $pixel, string $state): int;
+
     /**
      * Returns true if there are pending consented hits created before $delay seconds ago
      *

--- a/src/Repository/PixelEventRepositoryInterface.php
+++ b/src/Repository/PixelEventRepositoryInterface.php
@@ -32,5 +32,7 @@ interface PixelEventRepositoryInterface extends RepositoryInterface
      */
     public function findByBulkIdentifier(string $bulkIdentifier): array;
 
+    public function resetFailedByPixel(PixelInterface $pixel): void;
+
     public function removeSent(int $delay = 0): int;
 }

--- a/src/Resources/config/doctrine/model/Pixel.orm.xml
+++ b/src/Resources/config/doctrine/model/Pixel.orm.xml
@@ -17,6 +17,8 @@
         </id>
 
         <field name="pixelId" column="pixel_id" unique="true"/>
+        <field name="customAccessToken" column="custom_access_token" nullable="true"/>
+
         <field name="enabled" column="enabled" type="boolean"/>
 
         <many-to-many field="channels" target-entity="Sylius\Component\Channel\Model\ChannelInterface">

--- a/src/Resources/config/grids/setono_sylius_facebook_admin_pixel.yaml
+++ b/src/Resources/config/grids/setono_sylius_facebook_admin_pixel.yaml
@@ -10,8 +10,11 @@ sylius_grid:
                     class: "%setono_sylius_facebook.model.pixel.class%"
             fields:
                 pixelId:
-                    type: string
+                    type: twig
                     label: setono_sylius_facebook.ui.pixel_id
+                    path: .
+                    options:
+                        template: "@SetonoSyliusFacebookPlugin/Admin/Grid/Field/pixel.html.twig"
                 events_statistics:
                     type: twig
                     label: setono_sylius_facebook.ui.events_statistics

--- a/src/Resources/config/grids/setono_sylius_facebook_admin_pixel.yaml
+++ b/src/Resources/config/grids/setono_sylius_facebook_admin_pixel.yaml
@@ -1,4 +1,7 @@
 sylius_grid:
+    templates:
+        action:
+            setono_facebook_reset_failed_events: "@SetonoSyliusFacebookPlugin/Admin/Grid/Action/setono_facebook_reset_failed_events.html.twig"
     grids:
         setono_sylius_facebook_admin_pixel:
             driver:
@@ -41,5 +44,7 @@ sylius_grid:
                 item:
                     update:
                         type: update
+                    setono_facebook_reset_failed_events:
+                        type: setono_facebook_reset_failed_events
                     delete:
                         type: delete

--- a/src/Resources/config/grids/setono_sylius_facebook_admin_pixel.yaml
+++ b/src/Resources/config/grids/setono_sylius_facebook_admin_pixel.yaml
@@ -9,6 +9,12 @@ sylius_grid:
                 pixelId:
                     type: string
                     label: setono_sylius_facebook.ui.pixel_id
+                events_statistics:
+                    type: twig
+                    label: setono_sylius_facebook.ui.events_statistics
+                    path: .
+                    options:
+                        template: "@SetonoSyliusFacebookPlugin/Admin/Grid/Field/statistics.html.twig"
                 channels:
                     type: twig
                     label: sylius.ui.channels

--- a/src/Resources/config/routes/admin.yaml
+++ b/src/Resources/config/routes/admin.yaml
@@ -8,6 +8,8 @@ setono_sylius_facebook_admin_pixel:
         vars:
             all:
                 subheader: setono_sylius_facebook.ui.manage_pixels
+                templates:
+                    form: "@SetonoSyliusFacebookPlugin/Admin/Pixel/_form.html.twig"
             index:
                 icon: 'facebook'
     type: sylius.resource

--- a/src/Resources/config/routes/admin.yaml
+++ b/src/Resources/config/routes/admin.yaml
@@ -11,3 +11,14 @@ setono_sylius_facebook_admin_pixel:
             index:
                 icon: 'facebook'
     type: sylius.resource
+
+setono_sylius_facebook_admin_pixel_reset_failed_events:
+    path: /{id}/events/failed/reset
+    methods: [PATCH]
+    defaults:
+        _controller: setono_sylius_facebook.controller.action.pixel.reset_failed_events
+        _sylius:
+            section: admin
+            permission: true
+            redirect:
+                route: setono_sylius_facebook_admin_pixel_index

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -5,6 +5,7 @@
         <import resource="services/client.xml"/>
         <import resource="services/command.xml"/>
         <import resource="services/context.xml"/>
+        <import resource="services/controller.xml"/>
         <import resource="services/data_mapper.xml"/>
         <import resource="services/event_listener.xml"/>
         <import resource="services/factory.xml"/>

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -13,5 +13,6 @@
         <import resource="services/formatter.xml"/>
         <import resource="services/menu.xml"/>
         <import resource="services/server_side_factory.xml"/>
+        <import resource="services/twig.xml"/>
     </imports>
 </container>

--- a/src/Resources/config/services/controller.xml
+++ b/src/Resources/config/services/controller.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<container xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://symfony.com/schema/dic/services"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+    <services>
+        <defaults public="true"/>
+
+        <service id="setono_sylius_facebook.controller.action.pixel.reset_failed_events"
+                 class="Setono\SyliusFacebookPlugin\Controller\Action\Pixel\ResetFailedEventsAction">
+            <argument type="service" id="setono_sylius_facebook.repository.pixel" />
+            <argument type="service" id="security.csrf.token_manager" />
+            <argument type="service" id="setono_sylius_facebook.repository.pixel_event" />
+            <argument type="service" id="session" />
+            <argument type="service" id="router"/>
+        </service>
+    </services>
+</container>

--- a/src/Resources/config/services/controller.xml
+++ b/src/Resources/config/services/controller.xml
@@ -9,7 +9,6 @@
             <argument type="service" id="setono_sylius_facebook.repository.pixel" />
             <argument type="service" id="security.csrf.token_manager" />
             <argument type="service" id="setono_sylius_facebook.repository.pixel_event" />
-            <argument type="service" id="session" />
             <argument type="service" id="router"/>
         </service>
     </services>

--- a/src/Resources/config/services/twig.xml
+++ b/src/Resources/config/services/twig.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<container xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://symfony.com/schema/dic/services"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+    <services>
+        <service id="setono_sylius_facebook.twig.extension.events_pushing_statistics"
+                 class="Setono\SyliusFacebookPlugin\Twig\EventsPushingStatisticsExtension">
+            <argument type="service" id="setono_sylius_facebook.repository.pixel_event"/>
+
+            <tag name="twig.extension" />
+        </service>
+    </services>
+</container>

--- a/src/Resources/translations/flashes.en.yml
+++ b/src/Resources/translations/flashes.en.yml
@@ -1,0 +1,3 @@
+setono_sylius_facebook:
+    pixel:
+        failed_events_reset: 'Failed events reset'

--- a/src/Resources/translations/messages.en.yaml
+++ b/src/Resources/translations/messages.en.yaml
@@ -1,25 +1,25 @@
 setono_sylius_facebook:
     form:
         pixel:
-            pixel_id: Pixel id
-            pixel_id_placeholder: Insert your pixel id...
             custom_access_token: Pixel's access token
             custom_access_token_placeholder: |
-                Insert Facebook access token for this Pixel.
+                Insert Facebook access token for this pixel.
                 Leave it empty to use default one from plugin configuration.
+            pixel_id: Pixel id
+            pixel_id_placeholder: Insert your pixel id...
     ui:
-        reset_failed_events: Reset failed events
-        edit_pixel: Edit facebook pixel
-        facebook: Facebook
-        manage_pixels: Manage facebook pixels
-        new_pixel: New facebook pixel
-        pixel_id: Pixel id
         custom_access_token_specified: Custom token
-        pixels: Facebook pixels
-        no_channels: No channels
-        events_statistics: Statistics
-        no_events: No events
+        edit_pixel: Edit facebook pixel
         events_in_state:
             pending: Pending
             sent: Sent
             failed: Failed
+        events_statistics: Statistics
+        facebook: Facebook
+        manage_pixels: Manage facebook pixels
+        new_pixel: New facebook pixel
+        no_channels: No channels
+        no_events: No events
+        pixel_id: Pixel id
+        pixels: Facebook pixels
+        reset_failed_events: Reset failed events

--- a/src/Resources/translations/messages.en.yaml
+++ b/src/Resources/translations/messages.en.yaml
@@ -11,3 +11,9 @@ setono_sylius_facebook:
         pixel_id: Pixel id
         pixels: Facebook pixels
         no_channels: No channels
+        events_statistics: Statistics
+        no_events: No events
+        events_in_state:
+            pending: Pending
+            sent: Sent
+            failed: Failed

--- a/src/Resources/translations/messages.en.yaml
+++ b/src/Resources/translations/messages.en.yaml
@@ -4,6 +4,7 @@ setono_sylius_facebook:
             pixel_id: Pixel id
             pixel_id_placeholder: Insert your pixel id...
     ui:
+        reset_failed_events: Reset failed events
         edit_pixel: Edit facebook pixel
         facebook: Facebook
         manage_pixels: Manage facebook pixels

--- a/src/Resources/translations/messages.en.yaml
+++ b/src/Resources/translations/messages.en.yaml
@@ -14,6 +14,7 @@ setono_sylius_facebook:
         manage_pixels: Manage facebook pixels
         new_pixel: New facebook pixel
         pixel_id: Pixel id
+        custom_access_token_specified: Custom token
         pixels: Facebook pixels
         no_channels: No channels
         events_statistics: Statistics

--- a/src/Resources/translations/messages.en.yaml
+++ b/src/Resources/translations/messages.en.yaml
@@ -3,6 +3,10 @@ setono_sylius_facebook:
         pixel:
             pixel_id: Pixel id
             pixel_id_placeholder: Insert your pixel id...
+            custom_access_token: Pixel's access token
+            custom_access_token_placeholder: |
+                Insert Facebook access token for this Pixel.
+                Leave it empty to use default one from plugin configuration.
     ui:
         reset_failed_events: Reset failed events
         edit_pixel: Edit facebook pixel

--- a/src/Resources/translations/messages.en.yaml
+++ b/src/Resources/translations/messages.en.yaml
@@ -2,10 +2,10 @@ setono_sylius_facebook:
     form:
         pixel:
             custom_access_token: Pixel's access token
-            custom_access_token_placeholder: |
-                Insert Facebook access token for this pixel.
-                Leave it empty to use default one from plugin configuration.
+            custom_access_token_help: Leave it empty to use default one from plugin configuration
+            custom_access_token_placeholder: Insert Facebook access token for this pixel
             pixel_id: Pixel id
+            pixel_id_help: Get it from https://www.facebook.com/events_manager2
             pixel_id_placeholder: Insert your pixel id...
     ui:
         custom_access_token_specified: Custom token

--- a/src/Resources/views/Admin/Grid/Action/setono_facebook_reset_failed_events.html.twig
+++ b/src/Resources/views/Admin/Grid/Action/setono_facebook_reset_failed_events.html.twig
@@ -1,3 +1,5 @@
+{# @var \Setono\SyliusFacebookPlugin\Model\PixelInterface data #}
+
 {% import '@SetonoSyliusFacebookPlugin/Admin/Macro/buttons.html.twig' as buttons %}
 
 {% set path = options.link.url|default(path(
@@ -5,9 +7,12 @@
     options.link.parameters|default({'id': data.id})
 )) %}
 
-{{ buttons.resetFailedEvents(
-    path,
-    action.label|default('setono_sylius_facebook.ui.reset_failed_events'),
-    true,
-    data.id
-) }}
+{% set failedCount = setono_facebook_events_count_by_state(data, constant('Setono\\SyliusFacebookPlugin\\Model\\PixelEventInterface::STATE_FAILED')) %}
+{% if options.visible|default(failedCount > 0) %}
+    {{ buttons.resetFailedEvents(
+        path,
+        action.label|default('setono_sylius_facebook.ui.reset_failed_events'),
+        true,
+        data.id
+    ) }}
+{% endif %}

--- a/src/Resources/views/Admin/Grid/Action/setono_facebook_reset_failed_events.html.twig
+++ b/src/Resources/views/Admin/Grid/Action/setono_facebook_reset_failed_events.html.twig
@@ -1,0 +1,13 @@
+{% import '@SetonoSyliusFacebookPlugin/Admin/Macro/buttons.html.twig' as buttons %}
+
+{% set path = options.link.url|default(path(
+    options.link.route|default('setono_sylius_facebook_admin_pixel_reset_failed_events'),
+    options.link.parameters|default({'id': data.id})
+)) %}
+
+{{ buttons.resetFailedEvents(
+    path,
+    action.label|default('setono_sylius_facebook.ui.reset_failed_events'),
+    true,
+    data.id
+) }}

--- a/src/Resources/views/Admin/Grid/Field/pixel.html.twig
+++ b/src/Resources/views/Admin/Grid/Field/pixel.html.twig
@@ -1,0 +1,10 @@
+{# @var \Setono\SyliusFacebookPlugin\Model\PixelInterface data #}
+
+{{ data.pixelId }}
+
+{% if data.customAccessToken is not null %}
+    <div>
+        <i class="exclamation circle icon green"></i>
+        {{ 'setono_sylius_facebook.ui.custom_access_token_specified'|trans }}
+    </div>
+{% endif %}

--- a/src/Resources/views/Admin/Grid/Field/statistics.html.twig
+++ b/src/Resources/views/Admin/Grid/Field/statistics.html.twig
@@ -1,0 +1,10 @@
+{# @var \Setono\SyliusFacebookPlugin\Model\PixelInterface data #}
+
+{% for state, count in setono_facebook_events_pushing_statistics(data) %}
+    <div>
+        {{ ('setono_sylius_facebook.ui.events_in_state.' ~ state)|trans }}:
+        {{ count }}
+    </div>
+{% else %}
+    {{ 'setono_sylius_facebook.ui.no_events'|trans }}
+{% endfor %}

--- a/src/Resources/views/Admin/Macro/buttons.html.twig
+++ b/src/Resources/views/Admin/Macro/buttons.html.twig
@@ -1,0 +1,11 @@
+{% extends '@SyliusUi/Macro/buttons.html.twig' %}
+
+{% macro resetFailedEvents(url, message, labeled = true, resourceId = null) %}
+    <form action="{{ url }}" method="post">
+        <input type="hidden" name="_method" value="PATCH">
+        <button class="ui yellow {% if labeled %}labeled {% endif %}icon button" type="submit" data-requires-confirmation>
+            <i class="icon redo alternate"></i> {{ ((message is empty and labeled) ? 'setono_sylius_facebook.ui.reset_failed_events' : message)|trans }}
+        </button>
+        <input type="hidden" name="_csrf_token" value="{{ csrf_token(resourceId) }}" />
+    </form>
+{% endmacro %}

--- a/src/Resources/views/Admin/Pixel/_form.html.twig
+++ b/src/Resources/views/Admin/Pixel/_form.html.twig
@@ -1,0 +1,8 @@
+<div class="ui segment">
+    {{ form_errors(form) }}
+    <div class="two fields">
+        {{ form_row(form.pixelId) }}
+        {{ form_row(form.channels) }}
+    </div>
+    {{ form_row(form.enabled) }}
+</div>

--- a/src/Resources/views/Admin/Pixel/_form.html.twig
+++ b/src/Resources/views/Admin/Pixel/_form.html.twig
@@ -6,3 +6,6 @@
     </div>
     {{ form_row(form.enabled) }}
 </div>
+<div class="ui segment">
+    {{ form_row(form.customAccessToken) }}
+</div>

--- a/src/Twig/EventsPushingStatisticsExtension.php
+++ b/src/Twig/EventsPushingStatisticsExtension.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Setono\SyliusFacebookPlugin\Twig;
+
+use Setono\SyliusFacebookPlugin\Model\PixelInterface;
+use Setono\SyliusFacebookPlugin\Repository\PixelEventRepositoryInterface;
+use Setono\SyliusFacebookPlugin\Workflow\SendPixelEventWorkflow;
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFunction;
+
+final class EventsPushingStatisticsExtension extends AbstractExtension
+{
+    private PixelEventRepositoryInterface $pixelEventRepository;
+
+    public function __construct(PixelEventRepositoryInterface $pixelEventRepository)
+    {
+        $this->pixelEventRepository = $pixelEventRepository;
+    }
+
+    public function getFunctions(): array
+    {
+        return [
+            new TwigFunction('setono_facebook_events_pushing_statistics', [$this, 'getEventsPushingStatistics']),
+        ];
+    }
+
+    /**
+     * @return array<string, int>
+     */
+    public function getEventsPushingStatistics(PixelInterface $pixel): array
+    {
+        $result = [];
+        foreach (SendPixelEventWorkflow::getStates() as $state) {
+            $count = $this->pixelEventRepository->getCountByPixelAndState($pixel, $state);
+            if (0 === $count) {
+                continue;
+            }
+
+            $result[$state] = $count;
+        }
+
+        return $result;
+    }
+}

--- a/src/Twig/EventsPushingStatisticsExtension.php
+++ b/src/Twig/EventsPushingStatisticsExtension.php
@@ -23,6 +23,7 @@ final class EventsPushingStatisticsExtension extends AbstractExtension
     {
         return [
             new TwigFunction('setono_facebook_events_pushing_statistics', [$this, 'getEventsPushingStatistics']),
+            new TwigFunction('setono_facebook_events_count_by_state', [$this, 'getEventsCountByState']),
         ];
     }
 
@@ -42,5 +43,10 @@ final class EventsPushingStatisticsExtension extends AbstractExtension
         }
 
         return $result;
+    }
+
+    public function getEventsCountByState(PixelInterface $pixel, string $state): int
+    {
+        return $this->pixelEventRepository->getCountByPixelAndState($pixel, $state);
     }
 }

--- a/tests/Application/templates/bundles/SyliusUiBundle/Form/theme.html.twig
+++ b/tests/Application/templates/bundles/SyliusUiBundle/Form/theme.html.twig
@@ -1,0 +1,10 @@
+{% extends '@!SyliusUi/Form/theme.html.twig' %}
+
+{% block form_row -%}
+    <div class="{% if required %}required {% endif %}field{% if (not compound or force_error|default(false)) and not valid %} error{% endif %}">
+        {{- form_label(form) -}}
+        {{- form_widget(form) -}}
+        {{- form_help(form) -}}
+        {{- form_errors(form) -}}
+    </div>
+{%- endblock form_row %}

--- a/tests/Client/ClientTest.php
+++ b/tests/Client/ClientTest.php
@@ -58,6 +58,8 @@ final class ClientTest extends TestCase
         $pixel = new Pixel();
         $pixel->setPixelId($this->pixelId);
 
+        $eventTime = time();
+
         $pixelEvent = new PixelEvent();
         $pixelEvent->setPixel($pixel);
         $pixelEvent->setData([
@@ -66,7 +68,7 @@ final class ClientTest extends TestCase
                 'client_user_agent' => 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/94.0.4606.61 Safari/537.36',
             ],
             'event_name' => 'ViewContent',
-            'event_time' => 1635769396,
+            'event_time' => $eventTime,
             'custom_data' => [
                 'contents' => [
                     [
@@ -106,7 +108,7 @@ final class ClientTest extends TestCase
             Assert::string($requestOptions['body']);
             $requestBody = urldecode($requestOptions['body']);
 
-            $expected = sprintf('access_token=%s&data=[{"user_data":{"client_ip_address":"::1","client_user_agent":"Mozilla\/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/94.0.4606.61 Safari\/537.36"},"event_name":"ViewContent","event_time":1635769396,"custom_data":{"contents":[{"id":"Beige_strappy_summer_dress","quantity":1}],"content_ids":["Beige_strappy_summer_dress"],"content_name":"Beige strappy summer dress","content_type":"product"},"action_source":"website","event_source_url":"https:\/\/localhost:8000\/en_US\/products\/beige-strappy-summer-dress"}]', $this->accessToken);
+            $expected = sprintf('access_token=%s&data=[{"user_data":{"client_ip_address":"::1","client_user_agent":"Mozilla\/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/94.0.4606.61 Safari\/537.36"},"event_name":"ViewContent","event_time":%s,"custom_data":{"contents":[{"id":"Beige_strappy_summer_dress","quantity":1}],"content_ids":["Beige_strappy_summer_dress"],"content_name":"Beige strappy summer dress","content_type":"product"},"action_source":"website","event_source_url":"https:\/\/localhost:8000\/en_US\/products\/beige-strappy-summer-dress"}]', $this->accessToken, $eventTime);
             if (null !== $this->testEventCode) {
                 $expected .= sprintf('&test_event_code=%s', $this->testEventCode);
             }


### PR DESCRIPTION
Added ability to specify custom access token for Pixel.

If custom access token was not provided at Pixel admin form, default access token will be used from plugin configuration (`FACEBOOK_ACCESS_TOKEN`).

![image](https://user-images.githubusercontent.com/6544038/141140595-0b50e518-fdb2-4c8b-9822-422704c241cb.png)
