### PR TITLE
FBC/FBP support

### DIFF
--- a/src/DataMapper/RequestDataMapper.php
+++ b/src/DataMapper/RequestDataMapper.php
@@ -4,12 +4,20 @@ declare(strict_types=1);
 
 namespace Setono\SyliusFacebookPlugin\DataMapper;
 
+use Setono\SyliusFacebookPlugin\Manager\FbcManagerInterface;
 use Setono\SyliusFacebookPlugin\ServerSide\ServerSideEventInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Webmozart\Assert\Assert;
 
 /* not final */ class RequestDataMapper implements DataMapperInterface
 {
+    protected FbcManagerInterface $fbcManager;
+
+    public function __construct(FbcManagerInterface $fbcManager)
+    {
+        $this->fbcManager = $fbcManager;
+    }
+
     /**
      * @psalm-assert-if-true Request $context['request']
      */
@@ -37,5 +45,10 @@ use Webmozart\Assert\Assert;
 
         /** @psalm-suppress PossiblyNullArgument */
         $userData->setClientUserAgent($request->headers->get('User-Agent'));
+
+        $fbc = $this->fbcManager->getFbcValue();
+        if (is_string($fbc)) {
+            $userData->setFbc($fbc);
+        }
     }
 }

--- a/src/DataMapper/RequestDataMapper.php
+++ b/src/DataMapper/RequestDataMapper.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Setono\SyliusFacebookPlugin\DataMapper;
 
 use Setono\SyliusFacebookPlugin\Manager\FbcManagerInterface;
+use Setono\SyliusFacebookPlugin\Manager\FbpManagerInterface;
 use Setono\SyliusFacebookPlugin\ServerSide\ServerSideEventInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Webmozart\Assert\Assert;
@@ -13,9 +14,12 @@ use Webmozart\Assert\Assert;
 {
     protected FbcManagerInterface $fbcManager;
 
-    public function __construct(FbcManagerInterface $fbcManager)
+    protected FbpManagerInterface $fbpManager;
+
+    public function __construct(FbcManagerInterface $fbcManager, FbpManagerInterface $fbpManager)
     {
         $this->fbcManager = $fbcManager;
+        $this->fbpManager = $fbpManager;
     }
 
     /**
@@ -49,6 +53,11 @@ use Webmozart\Assert\Assert;
         $fbc = $this->fbcManager->getFbcValue();
         if (is_string($fbc)) {
             $userData->setFbc($fbc);
+        }
+
+        $fbp = $this->fbpManager->getFbpValue();
+        if (is_string($fbp)) {
+            $userData->setFbp($fbp);
         }
     }
 }

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -56,6 +56,10 @@ final class Configuration implements ConfigurationInterface
                     ->defaultValue(30 * 24 * 60 * 60) // 30 days
                     ->info('The number of seconds to wait until remove sent event')
                 ->end()
+                ->integerNode('fbc_ttl')
+                    ->defaultValue(28 * 24 * 60 * 60) // 28 days
+                    ->info('Time to live for fbc cookie')
+                ->end()
             ->end()
         ;
 

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -60,6 +60,10 @@ final class Configuration implements ConfigurationInterface
                     ->defaultValue(28 * 24 * 60 * 60) // 28 days
                     ->info('Time to live for fbc cookie')
                 ->end()
+                ->integerNode('fbp_ttl')
+                    ->defaultValue(365 * 24 * 60 * 60) // 365 days
+                    ->info('Time to live for fbp cookie')
+                ->end()
             ->end()
         ;
 

--- a/src/DependencyInjection/SetonoSyliusFacebookExtension.php
+++ b/src/DependencyInjection/SetonoSyliusFacebookExtension.php
@@ -18,7 +18,7 @@ final class SetonoSyliusFacebookExtension extends AbstractResourceExtension impl
         /**
          * @psalm-suppress PossiblyNullArgument
          *
-         * @var array{api_version: string, access_token: string, test_event_code: string|null, send_delay: int, cleanup_delay:int, fbc_ttl: int, driver: string, resources: array} $config
+         * @var array{api_version: string, access_token: string, test_event_code: string|null, send_delay: int, cleanup_delay:int, fbc_ttl: int, fbp_ttl: int, driver: string, resources: array} $config
          */
         $config = $this->processConfiguration($this->getConfiguration([], $container), $configs);
         $loader = new XmlFileLoader($container, new FileLocator(__DIR__ . '/../Resources/config'));
@@ -29,6 +29,7 @@ final class SetonoSyliusFacebookExtension extends AbstractResourceExtension impl
         $container->setParameter('setono_sylius_facebook.send_delay', $config['send_delay']);
         $container->setParameter('setono_sylius_facebook.cleanup_delay', $config['cleanup_delay']);
         $container->setParameter('setono_sylius_facebook.fbc_ttl', $config['fbc_ttl']);
+        $container->setParameter('setono_sylius_facebook.fbp_ttl', $config['fbp_ttl']);
 
         $loader->load('services.xml');
 

--- a/src/DependencyInjection/SetonoSyliusFacebookExtension.php
+++ b/src/DependencyInjection/SetonoSyliusFacebookExtension.php
@@ -18,7 +18,7 @@ final class SetonoSyliusFacebookExtension extends AbstractResourceExtension impl
         /**
          * @psalm-suppress PossiblyNullArgument
          *
-         * @var array{api_version: string, access_token: string, test_event_code: string|null, send_delay: int, cleanup_delay:int, driver: string, resources: array} $config
+         * @var array{api_version: string, access_token: string, test_event_code: string|null, send_delay: int, cleanup_delay:int, fbc_ttl: int, driver: string, resources: array} $config
          */
         $config = $this->processConfiguration($this->getConfiguration([], $container), $configs);
         $loader = new XmlFileLoader($container, new FileLocator(__DIR__ . '/../Resources/config'));
@@ -28,6 +28,7 @@ final class SetonoSyliusFacebookExtension extends AbstractResourceExtension impl
         $container->setParameter('setono_sylius_facebook.test_event_code', $config['test_event_code']);
         $container->setParameter('setono_sylius_facebook.send_delay', $config['send_delay']);
         $container->setParameter('setono_sylius_facebook.cleanup_delay', $config['cleanup_delay']);
+        $container->setParameter('setono_sylius_facebook.fbc_ttl', $config['fbc_ttl']);
 
         $loader->load('services.xml');
 

--- a/src/EventListener/StoreFbcSubscriber.php
+++ b/src/EventListener/StoreFbcSubscriber.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Setono\SyliusFacebookPlugin\EventListener;
+
+use Setono\BotDetectionBundle\BotDetector\BotDetectorInterface;
+use Setono\SyliusFacebookPlugin\Context\PixelContextInterface;
+use Setono\SyliusFacebookPlugin\Generator\PixelEventsGeneratorInterface;
+use Setono\SyliusFacebookPlugin\Manager\FbcManagerInterface;
+use Symfony\Bundle\SecurityBundle\Security\FirewallMap;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\HttpKernel\Event\ResponseEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
+
+final class StoreFbcSubscriber extends AbstractSubscriber
+{
+    private FbcManagerInterface $fbcManager;
+
+    public function __construct(
+        RequestStack $requestStack,
+        FirewallMap $firewallMap,
+        PixelContextInterface $pixelContext,
+        PixelEventsGeneratorInterface $pixelEventsGenerator,
+        BotDetectorInterface $botDetector,
+        FbcManagerInterface $fbcManager
+    ) {
+        parent::__construct(
+            $requestStack,
+            $firewallMap,
+            $pixelContext,
+            $pixelEventsGenerator,
+            $botDetector
+        );
+
+        $this->fbcManager = $fbcManager;
+    }
+
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            KernelEvents::RESPONSE => 'setFbcCookie',
+        ];
+    }
+
+    public function setFbcCookie(ResponseEvent $event): void
+    {
+        if (!$this->isRequestEligible()) {
+            return;
+        }
+
+        $fbcCookie = $this->fbcManager->getFbcCookie();
+        if (null === $fbcCookie) {
+            return;
+        }
+
+        $response = $event->getResponse();
+        $response->headers->setCookie($fbcCookie);
+    }
+}

--- a/src/Manager/FbcManager.php
+++ b/src/Manager/FbcManager.php
@@ -1,0 +1,135 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Setono\SyliusFacebookPlugin\Manager;
+
+use Symfony\Component\HttpFoundation\Cookie;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * We need this manager to be able to access fbc
+ * at different stages of Request and generate it only once
+ */
+final class FbcManager implements FbcManagerInterface
+{
+    private RequestStack $requestStack;
+
+    private int $fbcTtl;
+
+    private string $fbcCookieName;
+
+    /**
+     * Cached value of fbc generated from fbclid at current request
+     */
+    private ?string $generatedFbc = null;
+
+    public function __construct(
+        RequestStack $requestStack,
+        int $fbcTtl,
+        string $fbcCookieName = 'ssf_fbc'
+    ) {
+        $this->requestStack = $requestStack;
+        $this->fbcTtl = $fbcTtl;
+        $this->fbcCookieName = $fbcCookieName;
+    }
+
+    public function getFbcCookie(): ?Cookie
+    {
+        $fbc = $this->getFbcValue();
+        if (null === $fbc) {
+            return null;
+        }
+
+        return Cookie::create(
+            $this->fbcCookieName,
+            $fbc,
+            time() + $this->fbcTtl
+        );
+    }
+
+    /**
+     * We call it twice per request:
+     * 1. When populate fbc to UserData (on request)
+     * 2. When setting a fbc cookie (on response)
+     */
+    public function getFbcValue(): ?string
+    {
+        // We already have fbc generated at previous call
+        if (null !== $this->generatedFbc) {
+            return $this->generatedFbc;
+        }
+
+        $request = $this->requestStack->getCurrentRequest();
+        if (null === $request) {
+            return null;
+        }
+
+        /** @var string|null $fbc */
+        $fbc = $request->cookies->get($this->fbcCookieName);
+
+        /** @var string|null $fbclid */
+        $fbclid = $request->query->get('fbclid');
+
+        // We have both fbc and fbclid
+        if (is_string($fbclid) && is_string($fbc)) {
+            // So should decide if we should regenerate it.
+            // Extracting fbclid from fbc to compare
+            $existingFbclid = $this->extractFbclid($fbc);
+
+            // If fbclid is the same - we shouldn't regenerate fbc
+            // and use old one from cookie with old timestamp
+            if ($existingFbclid !== $fbclid) {
+                return $this->generateFbc($fbclid);
+            }
+        }
+
+        // We have fbc cookie and shouldn't try to
+        // regenerate it from fbclid (as it is empty)
+        if (is_string($fbc)) {
+            return $fbc;
+        }
+
+        // Have no fbc cookie, but have fbclid
+        // to generate fbc from it
+        if (is_string($fbclid)) {
+            return $this->generateFbc($fbclid);
+        }
+
+        // We have no fbc cookie and no fbclid, so can't generate
+        return null;
+    }
+
+    private function generateFbc(string $fbclid): string
+    {
+        $creationTime = ceil(microtime(true) * 1000);
+
+        $fbc = sprintf(
+            'fb.1.%s.%s',
+            $creationTime,
+            $fbclid
+        );
+
+        $this->generatedFbc = $fbc;
+
+        return $fbc;
+    }
+
+    private function extractFbclid(string $fbc): ?string
+    {
+        if (false === preg_match('/fb\.1\.(\d+)\.(.+)/', $fbc, $m)) {
+            return null;
+        }
+
+        if (!isset($m[2])) {
+            return null;
+        }
+
+        /** @var string $fbclid */
+        $fbclid = $m[2];
+
+        return $fbclid;
+    }
+}

--- a/src/Manager/FbcManagerInterface.php
+++ b/src/Manager/FbcManagerInterface.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Setono\SyliusFacebookPlugin\Manager;
+
+use Symfony\Component\HttpFoundation\Cookie;
+
+interface FbcManagerInterface
+{
+    public function getFbcCookie(): ?Cookie;
+
+    public function getFbcValue(): ?string;
+}

--- a/src/Manager/FbpManager.php
+++ b/src/Manager/FbpManager.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Setono\SyliusFacebookPlugin\Manager;
+
+use Setono\ClientId\Provider\ClientIdProviderInterface;
+use Symfony\Component\HttpFoundation\Cookie;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * We need this manager to be able to access fbp
+ * at different stages of Request and generate it only once
+ */
+final class FbpManager implements FbpManagerInterface
+{
+    private RequestStack $requestStack;
+
+    private ClientIdProviderInterface $clientIdProvider;
+
+    private int $fbpTtl;
+
+    private string $fbpCookieName;
+
+    public function __construct(
+        RequestStack $requestStack,
+        ClientIdProviderInterface $clientIdProvider,
+        int $fbpTtl,
+        string $fbpCookieName = 'ssf_fbp'
+    ) {
+        $this->requestStack = $requestStack;
+        $this->clientIdProvider = $clientIdProvider;
+        $this->fbpTtl = $fbpTtl;
+        $this->fbpCookieName = $fbpCookieName;
+    }
+
+    public function getfbpCookie(): ?Cookie
+    {
+        $fbp = $this->getfbpValue();
+        if (null === $fbp) {
+            return null;
+        }
+
+        return Cookie::create(
+            $this->fbpCookieName,
+            $fbp,
+            time() + $this->fbpTtl
+        );
+    }
+
+    /**
+     * We call it twice per request:
+     * 1. When populate fbp to UserData (on request)
+     * 2. When setting a fbp cookie (on response)
+     */
+    public function getFbpValue(): ?string
+    {
+        $request = $this->requestStack->getCurrentRequest();
+        if (null === $request) {
+            return null;
+        }
+
+        /** @var string|null $fbp */
+        $fbp = $request->cookies->get($this->fbpCookieName);
+
+        // We have fbp cookie and shouldn't try to
+        // regenerate it from fbplid (as it is empty)
+        if (is_string($fbp)) {
+            return $fbp;
+        }
+
+        $clientId = (string) $this->clientIdProvider->getClientId();
+
+        return $this->generateFbp($clientId);
+    }
+
+    private function generateFbp(string $clientId): string
+    {
+        $creationTime = ceil(microtime(true) * 1000);
+
+        return sprintf(
+            'fb.1.%s.%s',
+            $creationTime,
+            $clientId
+        );
+    }
+}

--- a/src/Manager/FbpManagerInterface.php
+++ b/src/Manager/FbpManagerInterface.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Setono\SyliusFacebookPlugin\Manager;
+
+use Symfony\Component\HttpFoundation\Cookie;
+
+interface FbpManagerInterface
+{
+    public function getFbpCookie(): ?Cookie;
+
+    public function getFbpValue(): ?string;
+}

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -9,6 +9,7 @@
         <import resource="services/data_mapper.xml"/>
         <import resource="services/event_listener.xml"/>
         <import resource="services/factory.xml"/>
+        <import resource="services/manager.xml"/>
         <import resource="services/fixture.xml"/>
         <import resource="services/form.xml"/>
         <import resource="services/formatter.xml"/>

--- a/src/Resources/config/services/data_mapper.xml
+++ b/src/Resources/config/services/data_mapper.xml
@@ -34,6 +34,7 @@
         <service id="setono_sylius_facebook.data_mapper.request"
                  class="Setono\SyliusFacebookPlugin\DataMapper\RequestDataMapper">
             <argument type="service" id="setono_sylius_facebook.manager.fbc" />
+            <argument type="service" id="setono_sylius_facebook.manager.fbp" />
 
             <tag name="setono_sylius_facebook.data_mapper" priority="100" />
         </service>

--- a/src/Resources/config/services/data_mapper.xml
+++ b/src/Resources/config/services/data_mapper.xml
@@ -33,6 +33,7 @@
 
         <service id="setono_sylius_facebook.data_mapper.request"
                  class="Setono\SyliusFacebookPlugin\DataMapper\RequestDataMapper">
+            <argument type="service" id="setono_sylius_facebook.manager.fbc" />
 
             <tag name="setono_sylius_facebook.data_mapper" priority="100" />
         </service>

--- a/src/Resources/config/services/event_listener.xml
+++ b/src/Resources/config/services/event_listener.xml
@@ -13,10 +13,11 @@
             <argument type="service" id="setono_bot_detection.bot_detector.default"/>
         </service>
 
-        <service id="setono_sylius_facebook.event_listener.store_fbc"
-                 class="Setono\SyliusFacebookPlugin\EventListener\StoreFbcSubscriber"
+        <service id="setono_sylius_facebook.event_listener.set_cookies"
+                 class="Setono\SyliusFacebookPlugin\EventListener\SetCookiesSubscriber"
                  parent="setono_sylius_facebook.event_listener.abstract">
             <argument type="service" id="setono_sylius_facebook.manager.fbc" />
+            <argument type="service" id="setono_sylius_facebook.manager.fbp" />
 
             <tag name="kernel.event_subscriber"/>
         </service>

--- a/src/Resources/config/services/event_listener.xml
+++ b/src/Resources/config/services/event_listener.xml
@@ -13,6 +13,14 @@
             <argument type="service" id="setono_bot_detection.bot_detector.default"/>
         </service>
 
+        <service id="setono_sylius_facebook.event_listener.store_fbc"
+                 class="Setono\SyliusFacebookPlugin\EventListener\StoreFbcSubscriber"
+                 parent="setono_sylius_facebook.event_listener.abstract">
+            <argument type="service" id="setono_sylius_facebook.manager.fbc" />
+
+            <tag name="kernel.event_subscriber"/>
+        </service>
+
         <service id="setono_sylius_facebook.event_listener.add_to_cart"
                  class="Setono\SyliusFacebookPlugin\EventListener\AddToCartSubscriber"
                  parent="setono_sylius_facebook.event_listener.abstract">

--- a/src/Resources/config/services/manager.xml
+++ b/src/Resources/config/services/manager.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<container xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://symfony.com/schema/dic/services"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+    <services>
+
+        <service id="setono_sylius_facebook.manager.fbc"
+                 class="Setono\SyliusFacebookPlugin\Manager\FbcManager">
+            <argument type="service" id="request_stack"/>
+            <argument>%setono_sylius_facebook.fbc_ttl%</argument>
+        </service>
+
+        <service id="Setono\SyliusFacebookPlugin\Manager\FbcManagerInterface"
+                 alias="setono_sylius_facebook.manager.fbc" />
+
+    </services>
+</container>

--- a/src/Resources/config/services/manager.xml
+++ b/src/Resources/config/services/manager.xml
@@ -12,5 +12,15 @@
         <service id="Setono\SyliusFacebookPlugin\Manager\FbcManagerInterface"
                  alias="setono_sylius_facebook.manager.fbc" />
 
+        <service id="setono_sylius_facebook.manager.fbp"
+                 class="Setono\SyliusFacebookPlugin\Manager\FbpManager">
+            <argument type="service" id="request_stack"/>
+            <argument type="service" id="setono_client_id.provider.default_client_id"/>
+            <argument>%setono_sylius_facebook.fbp_ttl%</argument>
+        </service>
+
+        <service id="Setono\SyliusFacebookPlugin\Manager\FbpManagerInterface"
+                 alias="setono_sylius_facebook.manager.fbp" />
+
     </services>
 </container>

--- a/tests/DependencyInjection/ConfigurationTest.php
+++ b/tests/DependencyInjection/ConfigurationTest.php
@@ -59,6 +59,7 @@ final class ConfigurationTest extends TestCase
             'send_delay' => 300,
             'cleanup_delay' => 2592000,
             'fbc_ttl' => 2419200,
+            'fbp_ttl' => 31536000,
         ]);
     }
 }

--- a/tests/DependencyInjection/ConfigurationTest.php
+++ b/tests/DependencyInjection/ConfigurationTest.php
@@ -58,6 +58,7 @@ final class ConfigurationTest extends TestCase
             'api_version' => 'v12.0',
             'send_delay' => 300,
             'cleanup_delay' => 2592000,
+            'fbc_ttl' => 2419200,
         ]);
     }
 }


### PR DESCRIPTION
Added: FBC parameter tracking

How it works:
- When we land on any page (not only ones we're tracking) with `?fbclid=xxx` - we generate and create `fbc` cookie
- Once we have new value at `fbclid` - `fbc` regenerates
- If we reload page with the same `fbclid` as it was before, `fbc` NOT regenerates to prevent timestamp update
- When we generate `UserData` for server side `Event` - we attach `fbc` from cookie

**Docs**
- https://developers.facebook.com/docs/marketing-api/conversions-api/parameters/customer-information-parameters/
- https://developers.facebook.com/docs/marketing-api/conversions-api/parameters/fbp-and-fbc

![image](https://user-images.githubusercontent.com/6544038/142665737-5efacbd7-cc3a-40d0-aa80-eb3d2c52e71a.png)
